### PR TITLE
add missing list template

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,24 @@
+{{ partial "header.html" . }}
+
+
+	<div class="row">
+		<div class="col-md-9">
+      {{ $page := .Paginate .Data.Pages }}
+      {{ range $page.Pages }}
+			<div class="well well-sm">
+      <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
+
+      <p><small>{{ .Description }}</small></p>
+      <p>{{ .Summary }}</p>
+
+      <a class="btn btn-primary btn-xs" href="{{ .Permalink }}">Read More <span class="fa fa-angle-double-right"></span></a>
+			</div>
+      {{ end }}
+		</div>
+
+		<!-- Sidebar -->
+		<div class="col-md-3">
+			{{ partial "menu.html" . }}
+		</div>
+	</div>
+{{ partial "footer.html" . }}


### PR DESCRIPTION
this site was missing a template for list pages [1]. I've added a
simple one as an example, but it will need a little more work to
exactly match your existing site.

[1]: https://gohugo.io/templates/lists/